### PR TITLE
Assembly

### DIFF
--- a/configs/conda.config
+++ b/configs/conda.config
@@ -11,7 +11,12 @@ process {
     withLabel: sortmerna { conda = "$baseDir/envs/sortmerna.yaml" } 
     withLabel: trinity { conda = "$baseDir/envs/trinity.yaml" } 
     withLabel: stringtie { conda = "$baseDir/envs/stringtie.yaml" } 
-    withLabel: busco { conda = "$baseDir/envs/busco.yaml" } 
-    withLabel: dammit { conda = "$baseDir/envs/dammit.yaml" } 
-    withLabel: dammitDB { conda = "$baseDir/envs/dammit.yaml" }
+
+    //withLabel: busco { conda = "$baseDir/envs/busco.yaml" } 
+    //withLabel: dammit { conda = "$baseDir/envs/dammit.yaml" } 
+    //withLabel: dammitDB { conda = "$baseDir/envs/dammit.yaml" }
+
+    withLabel: busco { container = 'nanozoo/busco:3.0.2--40d1506' } 
+    withLabel: dammit { container = 'nanozoo/dammit:1.2--b47259e' } 
+    withLabel: dammitDB { container = 'nanozoo/dammit:1.2--b47259e' }
 }

--- a/configs/conda.config
+++ b/configs/conda.config
@@ -9,4 +9,9 @@ process {
     withLabel: subread { conda = "$baseDir/envs/subread.yaml" } 
     withLabel: multiqc { conda = "$baseDir/envs/multiqc.yaml" } 
     withLabel: sortmerna { conda = "$baseDir/envs/sortmerna.yaml" } 
+    withLabel: trinity { conda = "$baseDir/envs/trinity.yaml" } 
+    withLabel: stringtie { conda = "$baseDir/envs/stringtie.yaml" } 
+    withLabel: busco { conda = "$baseDir/envs/busco.yaml" } 
+    withLabel: dammit { conda = "$baseDir/envs/dammit.yaml" } 
+    withLabel: dammitDB { conda = "$baseDir/envs/dammit.yaml" }
 }

--- a/configs/local.config
+++ b/configs/local.config
@@ -15,4 +15,9 @@ process {
     withLabel: subread { cpus = params.cores } 
     withLabel: multiqc { cpus = params.cores } 
     withLabel: sortmerna { cpus = params.cores } 
+    withLabel: trinity { cpus = params.cores; memory = params.memory } 
+    withLabel: stringtie { cpus = params.cores} 
+    withLabel: busco { cpus = params.cores } 
+    withLabel: dammit { cpus = params.cores } 
+    withLabel: dammitDB { cpus = 1 }
 }

--- a/configs/slurm.config
+++ b/configs/slurm.config
@@ -20,4 +20,9 @@ process {
     withLabel: fastqc { cpus = 1 ; memory = '2 GB' }
     withLabel: subread { cpus = 12 ; memory = '30 GB' }
     withLabel: sortmerna { cpus = 12 ; memory = '30 GB' }
+    withLabel: trinity { cpus = 24 ; memory = '40 GB' }
+    withLabel: stringtie { cpus = 24 ; memory = '40 GB' }
+    withLabel: busco { cpus = 8 } 
+    withLabel: dammit { cpus = 48 ; memory = '40 GB' } 
+    withLabel: dammitDB { cpus = 1 }
 }

--- a/envs/busco.yaml
+++ b/envs/busco.yaml
@@ -1,0 +1,6 @@
+name: busco
+channels:
+  - bioconda
+  - conda-forge
+dependencies:
+  - busco=3.0.2

--- a/envs/dammit.yaml
+++ b/envs/dammit.yaml
@@ -1,0 +1,7 @@
+name: dammit
+channels:
+  - conda-forge
+  - bioconda
+  - default
+dependencies:
+  - dammit=1.2

--- a/envs/stringtie.yaml
+++ b/envs/stringtie.yaml
@@ -1,0 +1,6 @@
+name: stringtie
+channels:
+  - bioconda
+dependencies:
+  - stringtie=2.1.1
+  - gffread=0.11.7

--- a/envs/trinity.yaml
+++ b/envs/trinity.yaml
@@ -1,0 +1,5 @@
+name: trinity
+channels:
+  - bioconda
+dependencies:
+  - trinity=2.9.1

--- a/main.nf
+++ b/main.nf
@@ -33,14 +33,14 @@ if (workflow.profile == 'standard' || workflow.profile.contains('local')) {
 }
 if (params.assembly) {
     println "\u001B[32mPerform assembly (de novo and reference-based) instead of gene expression analysis."
-}
-if (params.full) {
-    params.full_dir = 'full'
-    println "Use UniRef90 instead of UniRefKB for annotation: yes\033[0m"
-    println " "
-} else {
-    println "Use UniRef90 instead of UniRefKB for annotation: no\033[0m"
-    println " "
+    if (params.full) {
+        params.full_dir = 'full'
+        println "Use UniRef90 instead of UniRefKB for annotation: yes\033[0m"
+        println " "
+    } else {
+        println "Use UniRef90 instead of UniRefKB for annotation: no\033[0m"
+        println " "
+    }
 }
 
 Set species = ['hsa', 'eco', 'mmu', 'mau']

--- a/main.nf
+++ b/main.nf
@@ -484,10 +484,10 @@ workflow assembly_reference {
         stringtie_merge(genome_reference, stringtie.out.gtf.collect(), 'stringtie')
 
         // qc check
-        //busco(trinity.out.assembly, busco_db)    
+        busco(stringtie_merge.out.transcripts, busco_db)    
 
         // transcript annotation 
-        //dammit(trinity.out.assembly, dammit_db, 'trinity')
+        dammit(stringtie_merge.out.transcripts, dammit_db, 'stringtie')
 }
 
 

--- a/main.nf
+++ b/main.nf
@@ -486,7 +486,7 @@ workflow assembly_denovo {
         trinity(reads_ch, reads_input_csv)
 
         // qc check
-        busco(trinity.out.assembly, busco_db)    
+        busco(trinity.out.assembly, busco_db, 'trinity')    
 
         // transcript annotation 
         dammit(trinity.out.assembly, dammit_db, 'trinity')
@@ -511,7 +511,7 @@ workflow assembly_reference {
         stringtie_merge(genome_reference, stringtie.out.gtf.collect(), 'stringtie')
 
         // qc check
-        busco(stringtie_merge.out.transcripts, busco_db)    
+        busco(stringtie_merge.out.transcripts, busco_db, 'stringtie')    
 
         // transcript annotation 
         dammit(stringtie_merge.out.transcripts, dammit_db, 'stringtie')

--- a/main.nf
+++ b/main.nf
@@ -231,25 +231,25 @@ if ( ! (params.tpm instanceof java.lang.Double || params.tpm instanceof java.lan
 // databases
 include {referenceGet; concat_genome} from './modules/referenceGet'
 include {annotationGet; concat_annotation} from './modules/annotationGet'
-include sortmernaGet from './modules/sortmernaGet'
-include hisat2index from './modules/hisat2'
-include buscoGetDB from './modules/buscoGetDB'
-include dammitGetDB from './modules/dammitGetDB'
+include {sortmernaGet} from './modules/sortmernaGet'
+include {hisat2index} from './modules/hisat2'
+include {buscoGetDB} from './modules/buscoGetDB'
+include {dammitGetDB} from './modules/dammitGetDB'
 
 // analysis
-include fastp from './modules/fastp'
-include sortmerna from './modules/sortmerna'
-include hisat2 from './modules/hisat2'
-include featurecounts from './modules/featurecounts'
-include tpm_filter from './modules/tpm_filter'
-include deseq2 from './modules/deseq2'
+include {fastp} from './modules/fastp'
+include {sortmerna} from './modules/sortmerna'
+include {hisat2} from './modules/hisat2'
+include {featurecounts} from './modules/featurecounts'
+include {tpm_filter} from './modules/tpm_filter'
+include {deseq2} from './modules/deseq2'
 include { fastqc as fastqcPre; fastqc as fastqcPost } from './modules/fastqc'
 include { multiqc; multiqc_sample_names } from './modules/multiqc'
 
 // assembly & annotation
-include trinity from './modules/trinity'
-include busco from './modules/busco'
-include dammit from './modules/dammit'
+include {trinity} from './modules/trinity'
+include {busco} from './modules/busco'
+include {dammit} from './modules/dammit'
 include {stringtie; stringtie_merge} from './modules/stringtie' 
 
 // helpers

--- a/main.nf
+++ b/main.nf
@@ -31,8 +31,12 @@ if (workflow.profile == 'standard' || workflow.profile.contains('local')) {
     println "\033[2mCPUs to use: $params.cores, maximal CPS to use: $params.max_cores\u001B[0m"
     println " "
 }
+if (params.assembly) {
+    println "\u001B[32mPerform assembly (de novo and reference-based) instead of gene expression analysis.\033[0m"    
+    println " "
+}
 
-Set species = ['hsa', 'eco', 'mmu']
+Set species = ['hsa', 'eco', 'mmu', 'mau']
 
 if ( params.profile ) { exit 1, "--profile is WRONG use -profile" }
 if ( params.reads == '' ) { exit 1, "--reads is a required parameter" }
@@ -44,8 +48,8 @@ if ( params.species && ! (params.species in species) ) { exit 1, "Unsupported sp
 
 if ( params.dge ) { comparison = params.dge } else { comparison = 'all' }
 log.info """\
-    D I F F E R E N T I A L  G E N E  E X P R E S S I O N  A N A L Y S I S
-    = = = = = = = = = = = =  = = = =  = = = = = = = = = =  = = = = = = = =
+    R N A - S E Q  A S S E M B L Y  &  D I F F E R E N T I A L  G E N E  E X P R E S S I O N  A N A L Y S I S
+    = = = = = = =  = = = = = = = =  =  = = = = = = = = = = = =  = = = =  = = = = = = = = = =  = = = = = = = =
     Output path:          $params.output
     Mode:                 $params.mode
     Strandness:           $params.strand
@@ -211,6 +215,8 @@ include {referenceGet; concat_genome} from './modules/referenceGet'
 include {annotationGet; concat_annotation} from './modules/annotationGet'
 include sortmernaGet from './modules/sortmernaGet'
 include hisat2index from './modules/hisat2'
+include buscoGetDB from './modules/buscoGetDB'
+include dammitGetDB from './modules/dammitGetDB'
 
 // analysis
 include fastp from './modules/fastp'
@@ -221,6 +227,12 @@ include tpm_filter from './modules/tpm_filter'
 include deseq2 from './modules/deseq2'
 include { fastqc as fastqcPre; fastqc as fastqcPost } from './modules/fastqc'
 include { multiqc; multiqc_sample_names } from './modules/multiqc'
+
+// assembly & annotation
+include trinity from './modules/trinity'
+include busco from './modules/busco'
+include dammit from './modules/dammit'
+include {stringtie; stringtie_merge} from './modules/stringtie' 
 
 // helpers
 include {format_annotation; format_annotation_gene_rows} from './modules/prepare_annotation'
@@ -276,25 +288,44 @@ workflow download_sortmerna {
         sortmerna
 }
 
+workflow download_busco {
+    main:
+        if (!params.cloudProcess) { buscoGetDB() ; database_busco = buscoGetDB.out }
+        else if (params.cloudProcess) { 
+            busco_db_preload = file("${params.permanentCacheDir}/databases/busco/${params.busco}/${params.busco}.tar.gz")
+            if (busco_db_preload.exists()) { database_busco = busco_db_preload }
+            else  { buscoGetDB(); database_busco = buscoGetDB.out }
+        }
+    emit: database_busco
+}
+
+workflow download_dammit {
+    take: 
+    busco_db_ch
+    
+    main:
+        if (!params.cloudProcess) { dammitGetDB(busco_db_ch) ; database_dammit = dammitGetDB.out }
+        if (params.cloudProcess) { 
+            dammit_db_preload = file("${params.permanentCacheDir}/databases/dammit/${params.busco}/dbs.tar.gz")
+            if (dammit_db_preload.exists()) { database_dammit = dammit_db_preload }
+            else  { dammitGetDB(busco_db_ch); database_dammit = dammitGetDB.out }
+        }
+    emit: database_dammit
+}
+
+
 /************************** 
 * SUB WORKFLOWS
 **************************/
 
-/* Comment section: */
-
-
-workflow analysis_reference_based {
+/***************************************
+Preprocess RNA-Seq reads: qc, trimming, adapters, rRNA-removal, mapping
+*/
+workflow preprocess {
     take:
         illumina_input_ch
         reference
-        annotation
         sortmerna_db
-        dge_comparisons_input_ch
-        deseq2_script
-        deseq2_script_refactor_reportingtools_table
-        deseq2_script_improve_deseq_table
-        deseq2_script_csv2xlsx
-        multiqc_config
 
     main:
         // initial QC of raw reads
@@ -321,8 +352,39 @@ workflow analysis_reference_based {
         // map with HISAT2
         hisat2(sortmerna_no_rna_fastq, hisat2index.out, params.histat2_additional_params)
 
+    emit:
+        sample_bam_ch = hisat2.out.sample_bam
+        fastp_json_report = fastp.out.json_report
+        sortmerna_log
+        hisat2_log = hisat2.out.log  
+        fastqcPre = fastqcPre.out.zip  
+        fastqcPost = fastqcPost.out.zip
+        cleaned_reads_ch = sortmerna_no_rna_fastq
+} 
+
+
+/******************************************
+Differential gene expression analysis using a genome reference
+*/
+workflow expression_reference_based {
+    take:
+        sample_bam_ch
+        fastp_json_report
+        sortmerna_log
+        hisat2_log
+        fastqcPre
+        fastqcPost
+        annotation
+        dge_comparisons_input_ch
+        deseq2_script
+        deseq2_script_refactor_reportingtools_table
+        deseq2_script_improve_deseq_table
+        deseq2_script_csv2xlsx
+        multiqc_config
+
+    main:
         // count with featurecounts
-        featurecounts(hisat2.out.sample_bam, annotation)
+        featurecounts(sample_bam_ch, annotation)
 
         // prepare annotation for R input
         format_annotation_gene_rows(annotation)
@@ -368,20 +430,65 @@ workflow analysis_reference_based {
         multiqc_sample_names(annotated_reads.map{ row -> row[0..-3]}.collect())
         multiqc(multiqc_config, 
                 multiqc_sample_names.out,
-                fastp.out.json_report.collect(), 
+                fastp_json_report.collect(), 
                 sortmerna_log.collect().ifEmpty([]), 
-                hisat2.out.log.collect(), 
+                hisat2_log.collect(), 
                 featurecounts.out.log.collect(), 
-                fastqcPre.out.zip.collect(),
-                fastqcPost.out.zip.collect(),
+                fastqcPre.collect(),
+                fastqcPost.collect(),
                 tpm_filter.out.stats,
                 params.tpm
         )
 } 
 
-workflow analysis_de_novo {
-/*WIP. maybe later...*/
+/*****************************************
+De novo assembly of the preprocessed RNA-Seq reads. For now do co-assembly of all samples. 
+ToDo: also do co-assembly of samples belonging to the same condition. 
+*/
+workflow assembly_denovo {
+    take:
+        cleaned_reads_ch
+        busco_db
+        dammit_db
+
+    main:
+        reads_ch = cleaned_reads_ch.map {sample, reads -> tuple reads}.collect()
+        reads_input_csv = Channel.fromPath( params.reads, checkIfExists: true)
+ 
+        // co-assembly
+        trinity(reads_ch, reads_input_csv)
+
+        // qc check
+        busco(trinity.out.assembly, busco_db)    
+
+        // transcript annotation 
+        dammit(trinity.out.assembly, dammit_db, 'trinity')
 } 
+
+/*****************************************
+Reference-based assembly of the preprocessed RNA-Seq reads. 
+*/
+workflow assembly_reference {
+    take:
+        genome_reference
+        annotation_reference
+        bams
+        busco_db
+        dammit_db
+
+    main:
+        // StringTie2 GTF-guided transcript prediction
+        stringtie(genome_reference, annotation_reference, bams)
+
+        // Merge each single GTF-guided StringTie2 GTF file 
+        stringtie_merge(genome_reference, stringtie.out.gtf.collect(), 'stringtie')
+
+        // qc check
+        //busco(trinity.out.assembly, busco_db)    
+
+        // transcript annotation 
+        //dammit(trinity.out.assembly, dammit_db, 'trinity')
+}
 
 
 /************************** 
@@ -409,8 +516,35 @@ workflow {
     download_sortmerna()
     sortmerna_db = download_sortmerna.out
 
-    // start reference-based analysis
-    analysis_reference_based(illumina_input_ch, reference, annotation, sortmerna_db, dge_comparisons_input_ch, deseq2_script, deseq2_script_refactor_reportingtools_table, deseq2_script_improve_deseq_table, deseq2_script_csv2xlsx, multiqc_config)
+    // preprocess RNA-Seq reads
+    preprocess(illumina_input_ch, reference, sortmerna_db)
+
+    // perform assembly & annotation
+    if (params.assembly) {
+        // dbs
+        busco_db = download_busco()
+        dammit_db = download_dammit(busco_db)
+        // de novo
+        assembly_denovo(preprocess.out.cleaned_reads_ch, busco_db, dammit_db)
+        // reference-based
+        assembly_reference(reference, annotation, preprocess.out.sample_bam_ch, busco_db, dammit_db)
+    } else {
+    // perform expression analysis
+        // start reference-based differential gene expression analysis
+        expression_reference_based(preprocess.out.sample_bam_ch,
+                                preprocess.out.fastp_json_report,
+                                preprocess.out.sortmerna_log,
+                                preprocess.out.hisat2_log,
+                                preprocess.out.fastqcPre,
+                                preprocess.out.fastqcPost,
+                                annotation,
+                                dge_comparisons_input_ch, 
+                                deseq2_script, 
+                                deseq2_script_refactor_reportingtools_table, 
+                                deseq2_script_improve_deseq_table, 
+                                deseq2_script_csv2xlsx, 
+                                multiqc_config)
+    }
 }
 
 
@@ -425,6 +559,8 @@ def helpMSG() {
 
     ${c_yellow}Usage example:${c_reset}
     nextflow run main.nf --cores 4 --reads input.csv --species eco
+    or
+    nextflow run main.nf --cores 4 --reads input.csv --species eco --assembly
     or
     nextflow run main.nf --cores 4 --reads input.csv --genome fastas.csv --annotation gtfs.csv
     or
@@ -445,6 +581,7 @@ def helpMSG() {
     ${c_green}--annotation${c_reset}    CSV file with genome annotation GTF files (one path in each line)
 
     ${c_yellow}Options${c_reset}
+    --assembly               perform de novo and reference-based transcriptome assembly instead of DEG analysis [default $params.assembly]
     --dge                    a CSV file following the pattern: conditionX,conditionY
                              Each line stands for one differential gene expression comparison.
     --index                  the path to the hisat2 index prefix matching the genome provided via --species. 
@@ -455,6 +592,8 @@ def helpMSG() {
     --tpm                    threshold for TPM (transcripts per million) filter. A feature is discared, 
                              if in all conditions the mean TPM value of all libraries in this condition are below the threshold. [default $params.tpm]
     --skip_sortmerna         Skip rRNA removal via SortMeRNA [default $params.skip_sortmerna] 
+    --busco                 the database used with BUSCO [default: $params.busco]
+                ${c_dim}full list of available data sets at https://busco.ezlab.org/v2/frame_wget.html ${c_reset}
 
     ${c_dim}Computing options:
     --cores                  max cores per process for local use [default $params.cores]

--- a/main.nf
+++ b/main.nf
@@ -200,14 +200,25 @@ multiqc_config = Channel.fromPath( workflow.projectDir + '/assets/multiqc_config
 * CHECK INPUT
 */
 
-annotated_reads
-    .map{ row -> row[-2]}
-    .collect()
-    .subscribe onNext: {
-        for ( i in it ){
-        assert 2 <= it.count(i)
-        }
-    }, onError: { exit 1, 'You need at least 2 samples per condition to perform a differential gene expression analysis.' }
+if (params.assembly) {
+    annotated_reads
+        .map{ row -> row[-2]}
+        .collect()
+        .subscribe onNext: {
+            for ( i in it ){
+            assert 0 <= it.count(i)
+            }
+        }, onError: { exit 1, 'You need at least one sample to perform an assembly.' }
+} else {
+    annotated_reads
+        .map{ row -> row[-2]}
+        .collect()
+        .subscribe onNext: {
+            for ( i in it ){
+            assert 2 <= it.count(i)
+            }
+        }, onError: { exit 1, 'You need at least 2 samples per condition to perform a differential gene expression analysis.' }
+}
 
 if ( ! (params.tpm instanceof java.lang.Double || params.tpm instanceof java.lang.Float || params.tpm instanceof java.lang.Integer) ) {
     exit 1, "--tpm has to be numeric"

--- a/modules/annotationGet.nf
+++ b/modules/annotationGet.nf
@@ -33,6 +33,12 @@ process annotationGet {
       gunzip -f Escherichia_coli_k_12.ASM80076v1.45.gtf.gz
       mv Escherichia_coli_k_12.ASM80076v1.45.gtf ${species}.gtf
       """
+    else if (species == 'mau') 
+      """
+      wget ftp://ftp.ensembl.org/pub/release-100/gtf/mesocricetus_auratus/Mesocricetus_auratus.MesAur1.0.100.gtf.gz
+      gunzip -f Mesocricetus_auratus.MesAur1.0.100.gtf.gz
+      mv Mesocricetus_auratus.MesAur1.0.100.gtf ${species}.gtf
+      """
     else
       error "Invalid species: ${species}"
 }

--- a/modules/busco.nf
+++ b/modules/busco.nf
@@ -1,5 +1,7 @@
 process busco {
-    label 'busco'
+    //label 'busco'
+    container 'nanozoo/busco:3.0.2--40d1506'
+    
       publishDir "${params.output}/${params.annotation_dir}/busco", mode: 'copy', pattern: "busco_summary.txt"
       publishDir "${params.output}/${params.annotation_dir}/busco", mode: 'copy', pattern: "busco_figure.pdf"
     input:

--- a/modules/busco.nf
+++ b/modules/busco.nf
@@ -1,0 +1,31 @@
+process busco {
+    label 'busco'
+      publishDir "${params.output}/${params.annotation_dir}/busco", mode: 'copy', pattern: "${name}_busco_summary.txt"
+      publishDir "${params.output}/${params.annotation_dir}/busco", mode: 'copy', pattern: "${name}_busco_figure.pdf"
+    input:
+      path fasta
+      path database
+    output:
+      tuple path("busco_summary.txt"), path("busco_figure.pdf")
+      path "full_table_results.tsv"
+      """
+      tar -zxf ${database}
+
+      # run busco
+      run_BUSCO.py -i ${fasta} -o results -l ${params.busco} -m tran -c ${task.cpus} -t ./ -z
+      cp run_results/short_summary_results.txt busco_summary.txt
+
+      # generate Plot and rehack Rscript
+      generate_plot.py -wd run_results/
+      sed -i 's/busco_figure.png/busco_figure.pdf/g' run_results/busco_figure.R
+      Rscript run_results/busco_figure.R
+      cp run_results/busco_figure.pdf busco_figure.pdf
+      cp run_results/full_table_results.tsv full_table_results.tsv
+      """
+}
+
+/* Comments:
+Buscos plotting feature does not work in Docker by default.
+The "hack" modifies via sed the Rscript that gets generated after generate_plot.py
+After changing to pdf (circumventing resolutions) we rerun the script via Rscript. Tadaa... we have a plot
+*/

--- a/modules/busco.nf
+++ b/modules/busco.nf
@@ -1,7 +1,7 @@
 process busco {
     label 'busco'
-      publishDir "${params.output}/${params.annotation_dir}/busco", mode: 'copy', pattern: "${name}_busco_summary.txt"
-      publishDir "${params.output}/${params.annotation_dir}/busco", mode: 'copy', pattern: "${name}_busco_figure.pdf"
+      publishDir "${params.output}/${params.annotation_dir}/busco", mode: 'copy', pattern: "busco_summary.txt"
+      publishDir "${params.output}/${params.annotation_dir}/busco", mode: 'copy', pattern: "busco_figure.pdf"
     input:
       path fasta
       path database

--- a/modules/busco.nf
+++ b/modules/busco.nf
@@ -1,27 +1,28 @@
 process busco {
     label 'busco'
     
-      publishDir "${params.output}/${params.rnaseq_annotation_dir}/busco", mode: 'copy', pattern: "busco_summary.txt"
-      publishDir "${params.output}/${params.rnaseq_annotation_dir}/busco", mode: 'copy', pattern: "busco_figure.pdf"
+      publishDir "${params.output}/${params.rnaseq_annotation_dir}/busco", mode: 'copy', pattern: "busco_${tool}_summary.txt"
+      publishDir "${params.output}/${params.rnaseq_annotation_dir}/busco", mode: 'copy', pattern: "busco_${tool}_figure.pdf"
     input:
       path fasta
       path database
+      val tool
     output:
-      tuple path("busco_summary.txt"), path("busco_figure.pdf")
-      path "full_table_results.tsv"
+      tuple path("busco_${tool}_summary.txt"), path("busco_${tool}_figure.pdf")
+      path "full_table_${tool}_results.tsv"
       """
       tar -zxf ${database}
 
       # run busco
       run_BUSCO.py -i ${fasta} -o results -l ${params.busco} -m tran -c ${task.cpus} -t ./ -z
-      cp run_results/short_summary_results.txt busco_summary.txt
+      cp run_results/short_summary_results.txt busco_${tool}_summary.txt
 
       # generate Plot and rehack Rscript
       generate_plot.py -wd run_results/
       sed -i 's/busco_figure.png/busco_figure.pdf/g' run_results/busco_figure.R
       Rscript run_results/busco_figure.R
-      cp run_results/busco_figure.pdf busco_figure.pdf
-      cp run_results/full_table_results.tsv full_table_results.tsv
+      cp run_results/busco_figure.pdf busco_${tool}_figure.pdf
+      cp run_results/full_table_results.tsv full_table_${tool}_results.tsv
       """
 }
 

--- a/modules/busco.nf
+++ b/modules/busco.nf
@@ -1,9 +1,8 @@
 process busco {
-    //label 'busco'
-    container 'nanozoo/busco:3.0.2--40d1506'
+    label 'busco'
     
-      publishDir "${params.output}/${params.annotation_dir}/busco", mode: 'copy', pattern: "busco_summary.txt"
-      publishDir "${params.output}/${params.annotation_dir}/busco", mode: 'copy', pattern: "busco_figure.pdf"
+      publishDir "${params.output}/${params.rnaseq_annotation_dir}/busco", mode: 'copy', pattern: "busco_summary.txt"
+      publishDir "${params.output}/${params.rnaseq_annotation_dir}/busco", mode: 'copy', pattern: "busco_figure.pdf"
     input:
       path fasta
       path database

--- a/modules/buscoGetDB.nf
+++ b/modules/buscoGetDB.nf
@@ -1,6 +1,7 @@
 process buscoGetDB {
-    label 'busco'
-    label 'smallTask'
+    //label 'busco'
+    //label 'smallTask'
+    container 'nanozoo/busco:3.0.2--40d1506'
 
     if (params.cloudProcess) { publishDir "${params.permanentCacheDir}/databases/busco/${params.busco}", mode: 'copy', pattern: "${params.busco}.tar.gz" }
     else { storeDir "${params.permanentCacheDir}/databases/busco/${params.busco}" }  

--- a/modules/buscoGetDB.nf
+++ b/modules/buscoGetDB.nf
@@ -1,7 +1,6 @@
 process buscoGetDB {
-    //label 'busco'
-    //label 'smallTask'
-    container 'nanozoo/busco:3.0.2--40d1506'
+    label 'busco'
+    label 'smallTask'
 
     if (params.cloudProcess) { publishDir "${params.permanentCacheDir}/databases/busco/${params.busco}", mode: 'copy', pattern: "${params.busco}.tar.gz" }
     else { storeDir "${params.permanentCacheDir}/databases/busco/${params.busco}" }  

--- a/modules/buscoGetDB.nf
+++ b/modules/buscoGetDB.nf
@@ -1,0 +1,19 @@
+process buscoGetDB {
+    label 'busco'
+    label 'smallTask'
+
+    if (params.cloudProcess) { publishDir "${params.permanentCacheDir}/databases/busco/${params.busco}", mode: 'copy', pattern: "${params.busco}.tar.gz" }
+    else { storeDir "${params.permanentCacheDir}/databases/busco/${params.busco}" }  
+
+  output:
+    file("${params.busco}.tar.gz")
+
+  script:
+    """
+    wget http://busco.ezlab.org/v2/datasets/${params.busco}.tar.gz 
+    """
+}
+
+/*
+putting the database name into the channel for busco later on
+*/

--- a/modules/dammit.nf
+++ b/modules/dammit.nf
@@ -1,7 +1,6 @@
 process dammit {
-    //label 'dammitDB'
-    container 'nanozoo/dammit:1.2--b47259e'
-    publishDir "${params.output}/${params.annotation_dir}/dammit", mode: 'copy', pattern: "${tool}"
+    label 'dammit'
+    publishDir "${params.output}/${params.rnaseq_annotation_dir}/dammit/${params.full_dir}", mode: 'copy', pattern: "${tool}"
 
   input:
     path(transcriptome_assembly)
@@ -12,10 +11,19 @@ process dammit {
     tuple path("${tool}", type: 'dir'), path('uniprot_sprot_reduced.dat')
 
   script:
+    if (params.full)
     """
     tar zxvf ${dbs}
     BUSCO=\$(echo ${params.busco} | awk 'BEGIN{FS="_"};{print \$1}')
-    dammit annotate ${transcriptome_assembly} --database-dir \${PWD}/dbs --busco-group \${BUSCO} -n dammit -o ${tool} --n_threads ${task.cpus} #--full 
+    dammit annotate ${transcriptome_assembly} --database-dir \${PWD}/dbs --busco-group \${BUSCO} -n dammit -o ${tool} --n_threads ${task.cpus} --full 
+    cp dbs/uniprot_sprot_reduced.dat .
+    rm -rf dbs
+    """
+    else
+    """
+    tar zxvf ${dbs}
+    BUSCO=\$(echo ${params.busco} | awk 'BEGIN{FS="_"};{print \$1}')
+    dammit annotate ${transcriptome_assembly} --database-dir \${PWD}/dbs --busco-group \${BUSCO} -n dammit -o ${tool} --n_threads ${task.cpus}
     cp dbs/uniprot_sprot_reduced.dat .
     rm -rf dbs
     """

--- a/modules/dammit.nf
+++ b/modules/dammit.nf
@@ -4,18 +4,18 @@ process dammit {
     publishDir "${params.output}/${params.annotation_dir}/dammit", mode: 'copy', pattern: "${tool}"
 
   input:
-    tuple val(name), path(transcriptome_assembly)
+    path(transcriptome_assembly)
     path(dbs)
     val(tool)
 
   output:
-    tuple val(name), path("${tool}", type: 'dir'), path('uniprot_sprot_reduced.dat')
+    tuple path("${tool}", type: 'dir'), path('uniprot_sprot_reduced.dat')
 
   script:
     """
     tar zxvf ${dbs}
     BUSCO=\$(echo ${params.busco} | awk 'BEGIN{FS="_"};{print \$1}')
-    dammit annotate ${transcriptome_assembly} --database-dir \${PWD}/dbs --busco-group \${BUSCO} -n ${name} -o ${tool} --n_threads ${task.cpus} #--full 
+    dammit annotate ${transcriptome_assembly} --database-dir \${PWD}/dbs --busco-group \${BUSCO} -n dammit -o ${tool} --n_threads ${task.cpus} #--full 
     cp dbs/uniprot_sprot_reduced.dat .
     rm -rf dbs
     """

--- a/modules/dammit.nf
+++ b/modules/dammit.nf
@@ -1,0 +1,23 @@
+process dammit {
+    //label 'dammitDB'
+    container 'nanozoo/dammit:1.2--b47259e'
+    publishDir "${params.output}/${params.annotation_dir}/dammit", mode: 'copy', pattern: "${tool}"
+
+  input:
+    tuple val(name), path(transcriptome_assembly)
+    path(dbs)
+    val(tool)
+
+  output:
+    tuple val(name), path("${tool}", type: 'dir'), path('uniprot_sprot_reduced.dat')
+
+  script:
+    """
+    tar zxvf ${dbs}
+    BUSCO=\$(echo ${params.busco} | awk 'BEGIN{FS="_"};{print \$1}')
+    dammit annotate ${transcriptome_assembly} --database-dir \${PWD}/dbs --busco-group \${BUSCO} -n ${name} -o ${tool} --n_threads ${task.cpus} #--full 
+    cp dbs/uniprot_sprot_reduced.dat .
+    rm -rf dbs
+    """
+  }
+

--- a/modules/dammitGetDB.nf
+++ b/modules/dammitGetDB.nf
@@ -2,6 +2,9 @@ process dammitGetDB {
     label 'dammitDB'
     label 'smallTask'
 
+    errorStrategy 'retry'
+    maxRetries 2
+
     if (params.full) {
       if (params.cloudProcess) { publishDir "${params.permanentCacheDir}/databases/dammit/full/${params.busco}", mode: 'copy', pattern: "dbs.tar.gz" }
       else { storeDir "${params.permanentCacheDir}/databases/dammit/full/${params.busco}/" }  

--- a/modules/dammitGetDB.nf
+++ b/modules/dammitGetDB.nf
@@ -1,10 +1,15 @@
 process dammitGetDB {
-    //label 'dammitDB'
-    //label 'smallTask'
-    container 'nanozoo/dammit:1.2--b47259e'
+    label 'dammitDB'
+    label 'smallTask'
 
-    if (params.cloudProcess) { publishDir "${params.permanentCacheDir}/databases/dammit/${params.busco}", mode: 'copy', pattern: "dbs.tar.gz" }
-    else { storeDir "${params.permanentCacheDir}/databases/dammit/${params.busco}/" }  
+    if (params.full) {
+      if (params.cloudProcess) { publishDir "${params.permanentCacheDir}/databases/dammit/full/${params.busco}", mode: 'copy', pattern: "dbs.tar.gz" }
+      else { storeDir "${params.permanentCacheDir}/databases/dammit/full/${params.busco}/" }  
+    }
+    else {
+      if (params.cloudProcess) { publishDir "${params.permanentCacheDir}/databases/dammit/${params.busco}", mode: 'copy', pattern: "dbs.tar.gz" }
+      else { storeDir "${params.permanentCacheDir}/databases/dammit/${params.busco}/" }  
+    }
 
   input:
     path(busco_db)
@@ -13,9 +18,24 @@ process dammitGetDB {
     path("dbs.tar.gz")
 
   script:
+    if (params.full)
     """
     BUSCO=\$(echo ${params.busco} | awk 'BEGIN{FS="_"};{print \$1}')
-    dammit databases --install --database-dir \${PWD}/dbs --busco-group \${BUSCO} #--full
+    dammit databases --install --database-dir \${PWD}/dbs --busco-group \${BUSCO} --full
+    # the busco download fails so use the busco db we anyway already downloaded
+    tar -zxvf ${busco_db} -C dbs/busco2db/
+    # in addition, download metadata from uniprot/swissprot
+    wget ftp://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/complete/uniprot_sprot.dat.gz
+    gunzip uniprot_sprot.dat.gz
+    awk '{if(\$1=="ID" || \$1=="AC" || \$1=="DE" || \$1=="OS" || \$1=="OC" || \$2=="GO;"){print \$0}}' uniprot_sprot.dat > dbs/uniprot_sprot_reduced.dat
+    rm uniprot_sprot.dat
+    tar zcvf dbs.tar.gz dbs
+    rm -rf dbs
+    """
+  else
+    """
+    BUSCO=\$(echo ${params.busco} | awk 'BEGIN{FS="_"};{print \$1}')
+    dammit databases --install --database-dir \${PWD}/dbs --busco-group \${BUSCO}
     # the busco download fails so use the busco db we anyway already downloaded
     tar -zxvf ${busco_db} -C dbs/busco2db/
     # in addition, download metadata from uniprot/swissprot

--- a/modules/dammitGetDB.nf
+++ b/modules/dammitGetDB.nf
@@ -1,0 +1,30 @@
+process dammitGetDB {
+    //label 'dammitDB'
+    //label 'smallTask'
+    container 'nanozoo/dammit:1.2--b47259e'
+
+    if (params.cloudProcess) { publishDir "${params.permanentCacheDir}/databases/dammit/${params.busco}", mode: 'copy', pattern: "dbs.tar.gz" }
+    else { storeDir "${params.permanentCacheDir}/databases/dammit/${params.busco}/" }  
+
+  input:
+    path(busco_db)
+
+  output:
+    path("dbs.tar.gz")
+
+  script:
+    """
+    BUSCO=\$(echo ${params.busco} | awk 'BEGIN{FS="_"};{print \$1}')
+    dammit databases --install --database-dir \${PWD}/dbs --busco-group \${BUSCO} #--full
+    # the busco download fails so use the busco db we anyway already downloaded
+    tar -zxvf ${busco_db} -C dbs/busco2db/
+    # in addition, download metadata from uniprot/swissprot
+    wget ftp://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/complete/uniprot_sprot.dat.gz
+    gunzip uniprot_sprot.dat.gz
+    awk '{if(\$1=="ID" || \$1=="AC" || \$1=="DE" || \$1=="OS" || \$1=="OC" || \$2=="GO;"){print \$0}}' uniprot_sprot.dat > dbs/uniprot_sprot_reduced.dat
+    rm uniprot_sprot.dat
+    tar zcvf dbs.tar.gz dbs
+    rm -rf dbs
+    """
+}
+

--- a/modules/referenceGet.nf
+++ b/modules/referenceGet.nf
@@ -32,6 +32,12 @@ process referenceGet {
       gunzip -f Escherichia_coli_k_12.ASM80076v1.dna.toplevel.fa.gz
       mv Escherichia_coli_k_12.ASM80076v1.dna.toplevel.fa ${species}.fa
       """
+    else if (species == 'mau')
+      """
+      wget ftp://ftp.ensembl.org/pub/release-100/fasta/mesocricetus_auratus/dna/Mesocricetus_auratus.MesAur1.0.dna.toplevel.fa.gz
+      gunzip Mesocricetus_auratus.MesAur1.0.dna.toplevel.fa.gz
+      mv Mesocricetus_auratus.MesAur1.0.dna.toplevel.fa ${species}.fa
+      """
     else
       error "Invalid species: ${species}"
 }

--- a/modules/stringtie.nf
+++ b/modules/stringtie.nf
@@ -1,0 +1,70 @@
+process stringtie {
+    label 'stringtie'  
+    publishDir "${params.output}/${params.annotation_dir}/stringtie", mode: 'copy', pattern: "${sample_name}_stringtie.gtf"
+    //publishDir "${params.output}/${name}/${params.rnaseqdir}/stringtie", mode: 'copy', pattern: "${sample_name}_stringtie.fna"
+    publishDir "${params.output}/${params.annotation_dir}/stringtie", mode: 'copy', pattern: "${sample_name}_gene_abundance.txt"
+
+  input:
+    path genome
+    path gtf
+    tuple val(sample_name), file(bam)
+
+  output:
+    path "${sample_name}_stringtie.gtf", emit: gtf
+    path "${sample_name}_gene_abundance.txt", emit: abundance
+    //tuple val(name), file("${sample_name}_stringtie.fna"), emit: transcripts
+
+  script:
+    """
+      stringtie -G ${gtf} -p ${task.cpus} -o ${sample_name}_stringtie.gtf -A ${sample_name}_gene_abundance.txt ${bam} 
+      #gffread -w ${sample_name}_stringtie.fna -g ${genome} ${sample_name}_stringtie.gtf
+    """
+  }
+
+process stringtie_merge {
+    label 'stringtie'  
+    publishDir "${params.output}/${params.annotation_dir}/${mode}", mode: 'copy', pattern: "${mode}.gtf"
+    publishDir "${params.output}/${params.annotation_dir}/${mode}", mode: 'copy', pattern: "${mode}.fna"
+
+  input:
+    path(genome)
+    file(stringtie_gtfs)
+    val(mode)
+
+  output:
+    path "${mode}.gtf", emit: gtf
+    path "${mode}.fna", emit: transcripts
+
+  script:
+    """
+      stringtie --merge -o ${mode}.gtf *.gtf
+      gffread -w ${mode}.fna -g ${genome} ${mode}.gtf
+    """
+  }
+
+/*
+-G reference_guide.gff (gtf/gff3)
+
+THIS COULD BE INTERESTING TO USE INFORMATION FROM MULTIPLE RNA-SEQ FILES
+Transcript merge usage mode: 
+  stringtie --merge [Options] { gtf_list | strg1.gtf ...}
+With this option StringTie will assemble transcripts from multiple
+input files generating a unified non-redundant set of isoforms. In this mode
+the following options are available:
+  -G <guide_gff>   reference annotation to include in the merging (GTF/GFF3)
+  -o <out_gtf>     output file name for the merged transcripts GTF
+                    (default: stdout)
+  -m <min_len>     minimum input transcript length to include in the merge
+                    (default: 50)
+  -c <min_cov>     minimum input transcript coverage to include in the merge
+                    (default: 0)
+  -F <min_fpkm>    minimum input transcript FPKM to include in the merge
+                    (default: 1.0)
+  -T <min_tpm>     minimum input transcript TPM to include in the merge
+                    (default: 1.0)
+  -f <min_iso>     minimum isoform fraction (default: 0.01)
+  -g <gap_len>     gap between transcripts to merge together (default: 250)
+  -i               keep merged transcripts with retained introns; by default
+                   these are not kept unless there is strong evidence for them
+  -l <label>       name prefix for output transcripts (default: MSTRG)
+*/

--- a/modules/stringtie.nf
+++ b/modules/stringtie.nf
@@ -1,8 +1,8 @@
 process stringtie {
     label 'stringtie'  
-    publishDir "${params.output}/${params.annotation_dir}/stringtie", mode: 'copy', pattern: "${sample_name}_stringtie.gtf"
-    //publishDir "${params.output}/${name}/${params.rnaseqdir}/stringtie", mode: 'copy', pattern: "${sample_name}_stringtie.fna"
-    publishDir "${params.output}/${params.annotation_dir}/stringtie", mode: 'copy', pattern: "${sample_name}_gene_abundance.txt"
+    publishDir "${params.output}/${params.rnaseq_annotation_dir}/stringtie", mode: 'copy', pattern: "${sample_name}_stringtie.gtf"
+    //publishDir "${params.output}/${name}/${params.rnaseq_annotation_dir}/stringtie", mode: 'copy', pattern: "${sample_name}_stringtie.fna"
+    publishDir "${params.output}/${params.rnaseq_annotation_dir}/stringtie", mode: 'copy', pattern: "${sample_name}_gene_abundance.txt"
 
   input:
     path genome
@@ -23,8 +23,8 @@ process stringtie {
 
 process stringtie_merge {
     label 'stringtie'  
-    publishDir "${params.output}/${params.annotation_dir}/${mode}", mode: 'copy', pattern: "${mode}.gtf"
-    publishDir "${params.output}/${params.annotation_dir}/${mode}", mode: 'copy', pattern: "${mode}.fna"
+    publishDir "${params.output}/${params.rnaseq_annotation_dir}/${mode}", mode: 'copy', pattern: "${mode}.gtf"
+    publishDir "${params.output}/${params.rnaseq_annotation_dir}/${mode}", mode: 'copy', pattern: "${mode}.fna"
 
   input:
     path(genome)

--- a/modules/stringtie.nf
+++ b/modules/stringtie.nf
@@ -23,6 +23,9 @@ process stringtie {
 
 process stringtie_merge {
     label 'stringtie'  
+
+    errorStrategy { task.exitStatus = 1 ? 'ignore' :  'terminate' }
+
     publishDir "${params.output}/${params.rnaseq_annotation_dir}/${mode}", mode: 'copy', pattern: "${mode}.gtf"
     publishDir "${params.output}/${params.rnaseq_annotation_dir}/${mode}", mode: 'copy', pattern: "${mode}.fna"
 

--- a/modules/trinity.nf
+++ b/modules/trinity.nf
@@ -1,0 +1,46 @@
+process trinity {
+    label 'trinity'  
+    publishDir "${params.output}/${params.assembly_dir}/", mode: 'copy', pattern: "trinity.fasta"
+
+  input:
+    path reads 
+    path csv
+
+  output:
+    path "trinity.fasta", emit: assembly
+
+  script:
+    if (params.mode == 'paired')
+    """
+      # Update the original CSV file to match quality controlled reads and Trinity input
+      grep -v Condition ${csv} | awk 'BEGIN{FS=","}{print \$4"\\t"\$1"\\t"\$1".R1.other.fastq.gz\\t"\$1".R2.other.fastq.gz"}' > input.csv
+      MEM=\$(echo ${task.memory} | awk '{print \$1}')
+      Trinity --seqType fq --samples_file input.csv --max_memory \${MEM}G --CPU ${task.cpus}
+      mv trinity_out_dir/Trinity.fasta trinity.fasta
+    """
+    else if (params.mode == 'single')
+    """
+      # Update the original CSV file to match quality controlled reads and Trinity input
+      grep -v Condition ${csv} | awk 'BEGIN{FS=","}{print \$4"\\t"\$1"\\t"\$1".R1.other.fastq.gz}' > input.csv
+      MEM=\$(echo ${task.memory} | awk '{print \$1}')
+      Trinity --seqType fq --samples_file input.csv --max_memory \${MEM}G --CPU ${task.cpus}
+      mv trinity_out_dir/Trinity.fasta trinity.fasta
+    """
+    else 
+      error "Invalid read mode: ${params.mode}"
+  }
+
+
+
+
+
+/*
+#      --samples_file <string>         tab-delimited text file indicating biological replicate relationships.
+#                                   ex.
+#                                        cond_A    cond_A_rep1    A_rep1_left.fq    A_rep1_right.fq
+#                                        cond_A    cond_A_rep2    A_rep2_left.fq    A_rep2_right.fq
+#                                        cond_B    cond_B_rep1    B_rep1_left.fq    B_rep1_right.fq
+#                                        cond_B    cond_B_rep2    B_rep2_left.fq    B_rep2_right.fq
+#
+#                      # if single-end instead of paired-end, then leave the 4th column above empty.
+*/

--- a/modules/trinity.nf
+++ b/modules/trinity.nf
@@ -13,17 +13,17 @@ process trinity {
     if (params.mode == 'paired')
     """
       # Update the original CSV file to match quality controlled reads and Trinity input
-      grep -v Condition ${csv} | awk 'BEGIN{FS=","}{print \$4"\\t"\$1"\\t"\$1".R1.other.fastq.gz\\t"\$1".R2.other.fastq.gz"}' > input.csv
+      grep -v Condition ${csv} | awk 'BEGIN{FS=","}{print \$4"\\t"\$1"\\t"\$1".R1.other.fastq.gz\\t"\$1".R2.other.fastq.gz"}' > \$(basename \$PWD)_input.csv
       MEM=\$(echo ${task.memory} | awk '{print \$1}')
-      Trinity --seqType fq --samples_file input.csv --max_memory \${MEM}G --CPU ${task.cpus}
+      Trinity --seqType fq --samples_file \$(basename \$PWD)_input.csv --max_memory \${MEM}G --CPU ${task.cpus}
       mv trinity_out_dir/Trinity.fasta trinity.fasta
     """
     else if (params.mode == 'single')
     """
       # Update the original CSV file to match quality controlled reads and Trinity input
-      grep -v Condition ${csv} | awk 'BEGIN{FS=","}{print \$3"\\t"\$1"\\t"\$1".other.fastq.gz"}' > input.csv
+      grep -v Condition ${csv} | awk 'BEGIN{FS=","}{print \$3"\\t"\$1"\\t"\$1".other.fastq.gz"}' > \$(basename \$PWD)_input.csv
       MEM=\$(echo ${task.memory} | awk '{print \$1}')
-      Trinity --seqType fq --samples_file input.csv --max_memory \${MEM}G --CPU ${task.cpus}
+      Trinity --seqType fq --samples_file \$(basename \$PWD)_input.csv --max_memory \${MEM}G --CPU ${task.cpus}
       mv trinity_out_dir/Trinity.fasta trinity.fasta
     """
     else 

--- a/modules/trinity.nf
+++ b/modules/trinity.nf
@@ -21,7 +21,7 @@ process trinity {
     else if (params.mode == 'single')
     """
       # Update the original CSV file to match quality controlled reads and Trinity input
-      grep -v Condition ${csv} | awk 'BEGIN{FS=","}{print \$4"\\t"\$1"\\t"\$1".R1.other.fastq.gz}' > input.csv
+      grep -v Condition ${csv} | awk 'BEGIN{FS=","}{print \$3"\\t"\$1"\\t"\$1".other.fastq.gz"}' > input.csv
       MEM=\$(echo ${task.memory} | awk '{print \$1}')
       Trinity --seqType fq --samples_file input.csv --max_memory \${MEM}G --CPU ${task.cpus}
       mv trinity_out_dir/Trinity.fasta trinity.fasta

--- a/modules/trinity.nf
+++ b/modules/trinity.nf
@@ -1,6 +1,6 @@
 process trinity {
     label 'trinity'  
-    publishDir "${params.output}/${params.assembly_dir}/", mode: 'copy', pattern: "trinity.fasta"
+    publishDir "${params.output}/${params.assembly_dir}/trinity", mode: 'copy', pattern: "trinity.fasta"
 
   input:
     path reads 

--- a/modules/trinity.nf
+++ b/modules/trinity.nf
@@ -15,7 +15,7 @@ process trinity {
       # Update the original CSV file to match quality controlled reads and Trinity input
       grep -v Condition ${csv} | awk 'BEGIN{FS=","}{print \$4"\\t"\$1"\\t"\$1".R1.other.fastq.gz\\t"\$1".R2.other.fastq.gz"}' > \$(basename \$PWD)_input.csv
       MEM=\$(echo ${task.memory} | awk '{print \$1}')
-      Trinity --seqType fq --samples_file \$(basename \$PWD)_input.csv --max_memory \${MEM}G --CPU ${task.cpus}
+      Trinity --seqType fq --samples_file \$(basename \$PWD)_input.csv --max_memory \${MEM}G --bflyCalculateCPU --CPU ${task.cpus}
       mv trinity_out_dir/Trinity.fasta trinity.fasta
     """
     else if (params.mode == 'single')
@@ -23,12 +23,14 @@ process trinity {
       # Update the original CSV file to match quality controlled reads and Trinity input
       grep -v Condition ${csv} | awk 'BEGIN{FS=","}{print \$3"\\t"\$1"\\t"\$1".other.fastq.gz"}' > \$(basename \$PWD)_input.csv
       MEM=\$(echo ${task.memory} | awk '{print \$1}')
-      Trinity --seqType fq --samples_file \$(basename \$PWD)_input.csv --max_memory \${MEM}G --CPU ${task.cpus}
+      Trinity --seqType fq --samples_file \$(basename \$PWD)_input.csv --max_memory \${MEM}G --bflyCalculateCPU --CPU ${task.cpus}
       mv trinity_out_dir/Trinity.fasta trinity.fasta
     """
     else 
       error "Invalid read mode: ${params.mode}"
   }
+
+//In addition, the --bflyHeapSpaceMax is available. If you are confident that no instances of Butterfly will use all 10GB of memory, setting this to a smaller value may allow more Butterfly processes to run.
 
 
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -29,6 +29,7 @@ params {
     histat2_additional_params = ''
 
     busco = 'euarchontoglires_odb9'
+    full = ''
 
     skip_sortmerna = false
     assembly = ''
@@ -43,7 +44,8 @@ params {
     annotation_dir = '06-Annotation'
     deseq2_dir = '07-DifferentialExpression/deseq2'
     assembly_dir = '08-Assembly/de_novo'
-    annotation_dir = '09-Annotation/'
+    rnaseq_annotation_dir = '09-RNA-Seq_Annotation/'
+    full_dir = ''
     multiqc_dir = 'Summary'
 
     // location for autodownload data like databases

--- a/nextflow.config
+++ b/nextflow.config
@@ -2,6 +2,8 @@ manifest {
     mainScript = 'main.nf'
 }
 
+docker.enabled = true
+
 // default parameters
 params {
     max_cores = Runtime.runtime.availableProcessors()
@@ -26,7 +28,10 @@ params {
     fastp_additional_params = '-5 -3 -W 4 -M 20 -l 15 -x -n 5 -z 6'
     histat2_additional_params = ''
 
+    busco = 'euarchontoglires_odb9'
+
     skip_sortmerna = false
+    assembly = ''
   
     // folder structure
     output = 'results'
@@ -37,6 +42,8 @@ params {
     tpm_filter_dir = '05-CountingFilter/TPM'
     annotation_dir = '06-Annotation'
     deseq2_dir = '07-DifferentialExpression/deseq2'
+    assembly_dir = '08-Assembly/de_novo'
+    annotation_dir = '09-Annotation/'
     multiqc_dir = 'Summary'
 
     // location for autodownload data like databases


### PR DESCRIPTION
Added de novo and reference-based assembly support that can be activated via an `--assembly` switch. 

Tested on local laptop and mahlzeit. 

At the moment, BUSCO and DAMMIT are run in a Docker due to issues with solving correct condo envs: 

* dammit: it was not possible to build the env
* busco condo env worked on my laptop but failed on mahlzeit (I think this is likely a mahlzeit-user-account-special-issue)

Because the DEG part is not affected when the `--assembly` switch is not set, I suggest we can already merge this, @MarieLataretu ? 